### PR TITLE
[fix] node 0.12 socket close event does not always have payload

### DIFF
--- a/src/godot/net/client.coffee
+++ b/src/godot/net/client.coffee
@@ -190,7 +190,7 @@ class Client extends stream.Transform
 
     @emit "connect"
 
-  cleanup: ({had_error, error}) =>
+  cleanup: ({had_error, error} = {}) =>
     switch @type
       when "tcp", "tls", "unix"
         @serializer.unpipe @socket


### PR DESCRIPTION
As seen in https://travis-ci.org/nextorigin/godot2/jobs/179874983#L596